### PR TITLE
Fix issue with initializing gpio pins

### DIFF
--- a/droneinteract.py
+++ b/droneinteract.py
@@ -37,8 +37,8 @@ RECV_FAIL       = 2
 GPIO.setmode(GPIO.BCM)
 GPIO.setwarnings(False)
 
-deque(map(lambda pin: GPIO.setup(pin, GPIO.INPUT), GPIO_INPUT), 0)
-deque(map(lambda pin: GPIO.setup(pin, GPIO.OUTPUT), GPIO_OUTPUT), 0)
+deque(map(lambda pin: GPIO.setup(pin, GPIO.INPUT), GPIO_INPUT.values()), 0)
+deque(map(lambda pin: GPIO.setup(pin, GPIO.OUTPUT), GPIO_OUTPUT.values()), 0)
 
 def send_command(port):
     time.sleep(HOLD_TIME)


### PR DESCRIPTION
When initializing gpio pins, a dict was put in the `map()` function. Extracted pin values from the dict and passed them.